### PR TITLE
Fix wrong sample type in download description

### DIFF
--- a/html_spec_builder/templates/ble-specification-template.html
+++ b/html_spec_builder/templates/ble-specification-template.html
@@ -135,7 +135,7 @@
         </ul>
         <p>
             The next frames contain the measurement data for the selected sample type.<br/><br/>
-            The following image shows an example of a data download sequence for sample type 0x00.
+            The following image shows an example of a data download sequence for sample type 5.
             <img src="./static/BleDataDownload.png" alt="BLE Data Download" width="100%"/>
         </p>
         <section>


### PR DESCRIPTION
Sample type 5 is used in the download example picture and not sample type 0.